### PR TITLE
Log deprecation warnings to framework.log

### DIFF
--- a/lib/metasploit/framework.rb
+++ b/lib/metasploit/framework.rb
@@ -43,7 +43,15 @@ module Metasploit
 
       ActiveSupport::Deprecation.behavior = ->(message, callstack){
         wlog(message)
-        dlog(callstack.join('\n'))
+
+        indented_lines = callstack.collect { |line|
+          "  #{line}"
+        }
+        # put a blank line in front so no part of the actual callstack is affected by the logging format prefix
+        indented_lines.unshift ''
+        indented_backtrace = indented_lines.join("\n")
+
+        dlog(indented_backtrace)
       }
     end
   end


### PR DESCRIPTION
Originally: https://github.com/limhoff-r7/metasploit-framework/pull/5

MSP-8892

Override ActiveSupport::Deprecation.behavior to wlog message and dlog
callstack instead of printing to stderr.
