### PR TITLE
Metasploit::Framework::Scoped::Synchronization::Architecture#destination_attributes_set memoization bug

### DIFF
--- a/lib/metasploit/framework/scoped/synchronization/architecture.rb
+++ b/lib/metasploit/framework/scoped/synchronization/architecture.rb
@@ -57,6 +57,8 @@ module Metasploit::Framework::Scoped::Synchronization::Architecture
         }
       end
     end
+
+    @destination_attributes_set
   end
 
   def destroy_removed

--- a/spec/support/shared/examples/metasploit/framework/scoped/synchronization/architecture.rb
+++ b/spec/support/shared/examples/metasploit/framework/scoped/synchronization/architecture.rb
@@ -103,6 +103,55 @@ shared_examples_for 'Metasploit::Framework::Scoped::Synchronization::Architectur
     end
   end
 
+  context '#destination_attributes_set' do
+    subject(:destination_attributes_set) do
+      synchronization.destination_attributes_set
+    end
+
+    it 'should be memoized' do
+      memoization = double('#destination_attributes_set')
+      synchronization.instance_variable_set(:@destination_attributes_set, memoization)
+
+      destination_attributes_set.should == memoization
+    end
+
+    context 'with new record' do
+      it { should == Set.new }
+    end
+
+    context 'without new record' do
+      #
+      # lets
+      #
+
+      let(:destination) do
+        persistable_destination
+      end
+
+      #
+      # callbacks
+      #
+
+      before(:each) do
+        destination.save!
+      end
+
+      it { should be_a Set }
+
+      it 'should use #scope' do
+        synchronization.should_receive(:scope).and_call_original
+
+        destination_attributes_set
+      end
+
+      it 'should include architecture abbreviations' do
+        destination_attributes_set.should == Set.new(
+            destination.send(join_association).map(&:architecture).map(&:abbreviation)
+        )
+      end
+    end
+  end
+
   context '#destroy_removed' do
     subject(:destroy_removed) do
       synchronization.destroy_removed


### PR DESCRIPTION
MSP-9107

Add missing `@destination_attributes_set` at the end of the method,
outside the `unless`, so that the method doesn't return `nil` anymore
when called twice, but returns the memoized `Set` instead.
