### PR TITLE
Call create_database on correct object

### DIFF
--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -172,7 +172,7 @@ module Msf::DBManager::Connection
         creation_options = normalized_options.merge(
             'encoding' => encoding
         )
-        ActiveRecord::Base.create_database(database, creation_options)
+        ActiveRecord::Base.connection.create_database(database, creation_options)
 
         ActiveRecord::Base.establish_connection(normalized_options)
       rescue Exception => error

--- a/spec/support/shared/examples/msf/db_manager/connection/create_database/creating_database.rb
+++ b/spec/support/shared/examples/msf/db_manager/connection/create_database/creating_database.rb
@@ -40,7 +40,11 @@ shared_examples_for 'Msf::DBManager::Connection#create_database creating databas
       end
 
       it "should create database with ['encoding'] encoding" do
-        ActiveRecord::Base.should_receive(:create_database).with(
+        connection = double('ActiveRecord::Base.connection'
+        )
+
+        ActiveRecord::Base.should_receive(:connection).and_return(connection)
+        connection.should_receive(:create_database).with(
             database,
             hash_including(
                 'encoding' => option_encoding
@@ -74,7 +78,10 @@ shared_examples_for 'Msf::DBManager::Connection#create_database creating databas
         end
 
         it 'should create database with CHARSET encoding' do
-          ActiveRecord::Base.should_receive(:create_database).with(
+          connection = double('ActiveRecord::Base.connection')
+
+          ActiveRecord::Base.should_receive(:connection).and_return(connection)
+          connection.should_receive(:create_database).with(
               database,
               hash_including(
                   'encoding' => charset
@@ -88,7 +95,10 @@ shared_examples_for 'Msf::DBManager::Connection#create_database creating databas
 
       context "without CHARSET environment variable" do
         it 'should create database with default utf8 encoding' do
-          ActiveRecord::Base.should_receive(:create_database).with(
+          connection = double('ActiveRecord::Base#connection')
+
+          ActiveRecord::Base.should_receive(:connection).and_return(connection)
+          connection.should_receive(:create_database).with(
               database,
               hash_including(
                   'encoding' => 'utf8'
@@ -104,7 +114,11 @@ shared_examples_for 'Msf::DBManager::Connection#create_database creating databas
 
   it 'should establish connection to created database to verify creation' do
     ActiveRecord::Base.should_receive(:establish_connection).ordered
-    ActiveRecord::Base.should_receive(:create_database).ordered
+
+    connection = double("ActiveRecord::Base.connection")
+
+    ActiveRecord::Base.should_receive(:connection).ordered.and_return(connection)
+    connection.should_receive(:create_database).ordered
     ActiveRecord::Base.should_receive(:establish_connection).ordered
 
     create_database
@@ -112,7 +126,7 @@ shared_examples_for 'Msf::DBManager::Connection#create_database creating databas
 
   context 'with exception' do
     let(:exception) do
-      Exception.new('ActiveRecord::Base.create_database error')
+      Exception.new('ActiveRecord::Base.connection.create_database error')
     end
 
     before(:each) do
@@ -123,7 +137,7 @@ shared_examples_for 'Msf::DBManager::Connection#create_database creating databas
           )
       )
 
-      ActiveRecord::Base.stub(:create_database).and_raise(exception)
+      ActiveRecord::Base.stub_chain(:connection, :create_database).and_raise(exception)
     end
 
     it 'should set database_creation_error' do
@@ -149,7 +163,11 @@ shared_examples_for 'Msf::DBManager::Connection#create_database creating databas
               'schema_search_path' => 'public'
           )
       )
-      ActiveRecord::Base.should_receive(:create_database)
+
+      connection = double('ActiveRecord::Base.connection')
+
+      ActiveRecord::Base.should_receive(:connection).and_return(connection)
+      connection.should_receive(:create_database)
       ActiveRecord::Base.should_receive(:establish_connection).with(options)
     end
 

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
@@ -331,7 +331,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
 
 			context 'with :workspace' do
 				let(:workspace) do
-					mock(':workspace')
+					double(':workspace')
 				end
 
 				before(:each) do
@@ -481,7 +481,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
 			context 'specialization block' do
 				let(:returned_hash) do
 					{
-							:specialized => mock('Value')
+							:specialized => double('Value')
 					}
 				end
 

--- a/spec/support/shared/examples/msf/db_manager/migration.rb
+++ b/spec/support/shared/examples/msf/db_manager/migration.rb
@@ -193,7 +193,7 @@ shared_examples_for 'Msf::DBManager::Migration' do
       descendants = []
 
       1.upto(2) do |i|
-        descendants << mock("Descendant #{i}")
+        descendants << double("Descendant #{i}")
       end
 
       ActiveRecord::Base.stub(:descendants => descendants)


### PR DESCRIPTION
MSP-9106

create_database is defined on `ActiveRecord::Base#connection`, not
`ActiveRecord::Base` directly.  The specs didn't catch this because
creating a database has to be done with should_receives and stubs.  The
error was detected by doing `rake db:drop` and allowing `msfconsole` to
try to create the database.
